### PR TITLE
Hotfix/KafkaSource/Added explicit cast to string in parse_message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 setup(
     name='tgt_grease',
-    version='2.2.0',
+    version='2.2.1',
     license="MIT",
     description='GRE Application Service Engine',
     long_description="""

--- a/tgt_grease/enterprise/Model/KafkaSource.py
+++ b/tgt_grease/enterprise/Model/KafkaSource.py
@@ -237,7 +237,7 @@ class KafkaSource(object):
                     ioc.getLogger().trace("Subkey: {0} missing from message".format(sub_key), trace=True)
                     return {}
                 pointer = pointer[sub_key]
-            final[alias] = pointer
+            final[alias] = str(pointer)
 
         ioc.getLogger().trace("Message succesfully parsed", trace=True)
         return final


### PR DESCRIPTION
Hotfix: Added explicit cast to string in parse_message
  * Primary Contact: [Ronald Queensen](mailto:ronald.queensen@target.com)

### Purpose

Added explicit cast to string, to ensure that a message sent to scheduling will be handled correctly. 

### Expected Outcome

No scheduling bugs due to non-string value types
  
### Checklist
 - [x] Tests
 - [x] Documentation
 - [x] Maintainer Code Review
