### PR TITLE
removed encoding on fields in source docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 setup(
     name='tgt_grease',
-    version='2.3.0',
+    version='2.3.1',
     license="MIT",
     description='Modern distributed automation engine built with love by Target',
     long_description="""

--- a/tgt_grease/enterprise/Model/CentralScheduling.py
+++ b/tgt_grease/enterprise/Model/CentralScheduling.py
@@ -81,8 +81,8 @@ class Scheduling(object):
                             'failures': 0
                         }
                     },
-                    'source': str(source).encode('utf-8'),
-                    'configuration': str(configName).encode('utf-8'),
+                    'source': str(source),
+                    'configuration': str(configName),
                     'data': elem,
                     'createTime': datetime.datetime.utcnow(),
                     'expiry': Deduplication.generate_max_expiry_time(1)


### PR DESCRIPTION
# GREASE Developer Pull Request Checklist _removed encoding on fields in source docs_
###### USE THIS TEMPLATE FOR YOUR PULL REQUEST!

  * Primary Contact: [Cory Hollinger](mailto:cory.hollinger@target.com)

### Purpose

This encoding was causing it to be deserialized as `bytes`, which was causing issues during rescheduling. These fields are only used in the daemon, which does type checking, so it will not affect anything else.

### Expected Outcome

Rescheduling doesn't give garbage config names.
  
### Checklist
 - [ ] Tests
 - [ ] Documentation
 - [ ] Maintainer Code Review
