### PR TITLE
Added generic Exception catch in Importer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 setup(
     name='tgt_grease',
-    version='2.3.2',
+    version='2.3.3',
     license="MIT",
     description='Modern distributed automation engine built with love by Target',
     long_description="""

--- a/tgt_grease/core/Importer.py
+++ b/tgt_grease/core/Importer.py
@@ -39,7 +39,7 @@ class ImportTool(object):
                 continue
             if not className.startswith("__") and className in dir(SearchModule):
                 try:
-                    req = getattr(SearchModule, str(className))
+                    req = self.get_attr(SearchModule, str(className))
                     instance = req()
                     return instance
                 except AttributeError:
@@ -58,3 +58,17 @@ class ImportTool(object):
                         verbose=True
                     )
         return None
+
+    def get_attr(self, object, name, default=None):
+        """Wrapper function for the built-in getattr function. Wrapper is required to mock the built-in function.
+
+        Args:
+            object (Any object): Object you are searching for a named attribute for
+            name (str): Name of the attribute you want to get from object
+            default (Any object): Return value if attribute name is not found in object. Raises exception if no default is provided.
+
+        Returns:
+            object: If an attribute is found it is returned. If it is not found, default is returned. 
+
+        """
+        return getattr(object, name, default)

--- a/tgt_grease/core/Importer.py
+++ b/tgt_grease/core/Importer.py
@@ -37,9 +37,9 @@ class ImportTool(object):
             except ImportError:
                 self._log.error("Failed to import module [{0}]".format(path), verbose=True)
                 continue
-            if not className.startswith("__") and className in dir(SearchModule):
+            if not className.startswith("__") and self._dir_contains(SearchModule, className):
                 try:
-                    req = self.get_attr(SearchModule, str(className))
+                    req = self._get_attr(SearchModule, str(className))
                     instance = req()
                     return instance
                 except AttributeError:
@@ -59,7 +59,7 @@ class ImportTool(object):
                     )
         return None
 
-    def get_attr(self, object, name, default=None):
+    def _get_attr(self, object, name, default=None):
         """Wrapper function for the built-in getattr function. Wrapper is required to mock the built-in function.
 
         Args:
@@ -72,3 +72,15 @@ class ImportTool(object):
 
         """
         return getattr(object, name, default)
+
+    def _dir_contains(self, module, name):
+        """Wrapper function for built in dir function. Needed for mocking. 
+
+        Args:
+            module (module): Module you are searching, imported with importlib.import_module
+            name (str): Attribute (class) name you are searching the module for
+
+        Returns:
+            Bool: Returns true if module contains name, else false.
+        """
+        return name in dir(module)

--- a/tgt_grease/core/Importer.py
+++ b/tgt_grease/core/Importer.py
@@ -37,12 +37,9 @@ class ImportTool(object):
             except ImportError:
                 self._log.error("Failed to import module [{0}]".format(path), verbose=True)
                 continue
-            if className in dir(SearchModule):
-                if className.startswith("__"):
-                    # No need to try magic methods
-                    continue
-                req = getattr(SearchModule, str(className))
+            if not className.startswith("__") and className in dir(SearchModule):
                 try:
+                    req = getattr(SearchModule, str(className))
                     instance = req()
                     return instance
                 except AttributeError:
@@ -50,10 +47,14 @@ class ImportTool(object):
                         "ATTRERROR: Failed to create instance of class [{0}] from module [{1}]".format(className, path),
                         verbose=True
                     )
-                    continue
                 except TypeError:
                     self._log.error(
                         "TYPEERROR: Failed to create instance of class [{0}] from module [{1}]".format(className, path),
+                        verbose=True
+                    )
+                except Exception as e:
+                    self._log.error(
+                        "{0}: Failed to create instance of class [{1}] from module [{2}]".format(str(type(e)).upper(), className, path),
                         verbose=True
                     )
         return None

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -28,7 +28,6 @@ class TestImporter(TestCase):
 
         times_called = 0
         def return_true_once(*args, **kwargs):
-            nonlocal times_called
             times_called += 1
             return times_called == 1
 

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -17,7 +17,7 @@ class TestImporter(TestCase):
         self.assertFalse(obj)
 
     @patch("importlib.import_module")
-    @patch("tgt_grease.core.ImportTool.load.getattr")
+    @patch("tgt_grease.core.ImportTool.get_attr")
     def test_init_exception(self, mock_getattr, mock_import):
         log = Logging()
         imp = ImportTool(log)

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -26,7 +26,12 @@ class TestImporter(TestCase):
         def raise_exception():
             raise Exception("Test Exception")
 
-        mock_dir_contains.return_value = True
+        times_called = 0
+        def return_true_once():
+            times_called += 1
+            return times_called == 1
+
+        mock_dir_contains.side_effect = return_true_once
         mock_req = MagicMock()
         mock_req.side_effect = raise_exception
         mock_getattr.return_value = mock_req

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -17,7 +17,7 @@ class TestImporter(TestCase):
         self.assertFalse(obj)
 
     @patch("importlib.import_module")
-    @patch("load.getattr")
+    @patch("ImportTool.load.getattr")
     def test_init_exception(self, mock_getattr, mock_import):
         log = Logging()
         imp = ImportTool(log)

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -27,7 +27,8 @@ class TestImporter(TestCase):
             raise Exception("Test Exception")
 
         times_called = 0
-        def return_true_once():
+        def return_true_once(*args, **kwargs):
+            nonlocal times_called
             times_called += 1
             return times_called == 1
 

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -17,7 +17,7 @@ class TestImporter(TestCase):
         self.assertFalse(obj)
 
     @patch("importlib.import_module")
-    @patch("ImportTool.load.getattr")
+    @patch("tgt_grease.core.Importer.load.getattr")
     def test_init_exception(self, mock_getattr, mock_import):
         log = Logging()
         imp = ImportTool(log)

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -26,7 +26,7 @@ class TestImporter(TestCase):
         def raise_exception():
             raise Exception("Test Exception")
 
-        d = {'times_called': 0}
+        d = {'times_called': 0} #Need mutable object for nonlocal updates
         def return_true_once(*args, **kwargs):
             d['times_called'] += 1
             return d['times_called'] == 1

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -17,7 +17,7 @@ class TestImporter(TestCase):
         self.assertFalse(obj)
 
     @patch("importlib.import_module")
-    @patch("tgt_grease.core.Importer.load.getattr")
+    @patch("tgt_grease.core.ImportTool.load.getattr")
     def test_init_exception(self, mock_getattr, mock_import):
         log = Logging()
         imp = ImportTool(log)

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -17,7 +17,7 @@ class TestImporter(TestCase):
         self.assertFalse(obj)
 
     @patch("importlib.import_module")
-    @patch("getattr")
+    @patch("load.getattr")
     def test_init_exception(self, mock_getattr, mock_import):
         log = Logging()
         imp = ImportTool(log)
@@ -32,5 +32,3 @@ class TestImporter(TestCase):
         self.assertEqual(imp.load("mock_class"), None)
         mock_getattr.assert_called_once()
         mock_req.assert_called_once()
-
-

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from tgt_grease.core import ImportTool, Configuration, Logging
+from mock import MagicMock, patch
 
 
 class TestImporter(TestCase):
@@ -14,3 +15,22 @@ class TestImporter(TestCase):
         imp = ImportTool(log)
         obj = imp.load("defaultdict")
         self.assertFalse(obj)
+
+    @patch("importlib.import_module")
+    @patch("getattr")
+    def test_init_exception(self, mock_getattr, mock_import):
+        log = Logging()
+        imp = ImportTool(log)
+
+        def raise_exception():
+            raise Exception("Test Exception")
+
+        mock_req = MagicMock()
+        mock_req.side_effect = raise_exception
+        mock_getattr.return_value = mock_req
+
+        self.assertEqual(imp.load("mock_class"), None)
+        mock_getattr.assert_called_once()
+        mock_req.assert_called_once()
+
+

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -16,15 +16,17 @@ class TestImporter(TestCase):
         obj = imp.load("defaultdict")
         self.assertFalse(obj)
 
+    @patch("tgt_grease.core.ImportTool._dir_contains")
     @patch("importlib.import_module")
-    @patch("tgt_grease.core.ImportTool.get_attr")
-    def test_init_exception(self, mock_getattr, mock_import):
+    @patch("tgt_grease.core.ImportTool._get_attr")
+    def test_init_exception(self, mock_getattr, mock_import, mock_dir_contains):
         log = Logging()
         imp = ImportTool(log)
 
         def raise_exception():
             raise Exception("Test Exception")
 
+        mock_dir_contains.return_value = True
         mock_req = MagicMock()
         mock_req.side_effect = raise_exception
         mock_getattr.return_value = mock_req

--- a/tgt_grease/core/tests/test_importer.py
+++ b/tgt_grease/core/tests/test_importer.py
@@ -26,10 +26,10 @@ class TestImporter(TestCase):
         def raise_exception():
             raise Exception("Test Exception")
 
-        times_called = 0
+        d = {'times_called': 0}
         def return_true_once(*args, **kwargs):
-            times_called += 1
-            return times_called == 1
+            d['times_called'] += 1
+            return d['times_called'] == 1
 
         mock_dir_contains.side_effect = return_true_once
         mock_req = MagicMock()

--- a/tgt_grease/enterprise/Sources/tests/test_sql_parser.py
+++ b/tgt_grease/enterprise/Sources/tests/test_sql_parser.py
@@ -16,33 +16,36 @@ class TestSQLSource(TestCase):
 
     def __ensure_schema(self):
         # Helper function
-        if not os.environ.get('GREASE_TEST_DSN'):
-            os.environ['GREASE_TEST_DSN'] = "host=localhost user=postgres"
-        with psycopg2.connect(os.environ['GREASE_TEST_DSN']) as conn:
-            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-            with conn.cursor() as cursor:
-                # just to make sure nothing exists
-                try:
-                    cursor.execute("""
-                      SELECT  
-                        pg_terminate_backend(pid) 
-                        FROM pg_stat_activity 
-                        WHERE datname='test_data'
-                    """)
-                    cursor.execute("""
-                        DROP DATABASE test_data;
-                    """)
-                except:
-                    print("Exception occurred during ensure schema... most of the time this is fine")
-                try:
-                    cursor.execute("""
-                        CREATE DATABASE test_data;
-                    """)
-                except psycopg2.ProgrammingError as e:
-                    print("Schema Exists: {0}".format(e.pgerror))
-        if not os.environ.get('GREASE_TEST_DSN_ORIGINAL'):
-            os.environ['GREASE_TEST_DSN_ORIGINAL'] = os.environ.get('GREASE_TEST_DSN')
-        os.environ['GREASE_TEST_DSN'] = os.environ['GREASE_TEST_DSN'] + " dbname=test_data"
+        try:
+            if not os.environ.get('GREASE_TEST_DSN'):
+                os.environ['GREASE_TEST_DSN'] = "host=localhost user=postgres"
+            with psycopg2.connect(os.environ['GREASE_TEST_DSN']) as conn:
+                conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+                with conn.cursor() as cursor:
+                    # just to make sure nothing exists
+                    try:
+                        cursor.execute("""
+                        SELECT  
+                            pg_terminate_backend(pid) 
+                            FROM pg_stat_activity 
+                            WHERE datname='test_data'
+                        """)
+                        cursor.execute("""
+                            DROP DATABASE test_data;
+                        """)
+                    except:
+                        print("Exception occurred during ensure schema... most of the time this is fine")
+                    try:
+                        cursor.execute("""
+                            CREATE DATABASE test_data;
+                        """)
+                    except psycopg2.ProgrammingError as e:
+                        print("Schema Exists: {0}".format(e.pgerror))
+            if not os.environ.get('GREASE_TEST_DSN_ORIGINAL'):
+                os.environ['GREASE_TEST_DSN_ORIGINAL'] = os.environ.get('GREASE_TEST_DSN')
+            os.environ['GREASE_TEST_DSN'] = os.environ['GREASE_TEST_DSN'] + " dbname=test_data"
+        except:
+            print("Exception occurred")
 
     def __cleanup_schema(self):
         with psycopg2.connect(os.environ['GREASE_TEST_DSN_ORIGINAL']) as conn:

--- a/tgt_grease/enterprise/Sources/tests/test_sql_parser.py
+++ b/tgt_grease/enterprise/Sources/tests/test_sql_parser.py
@@ -44,8 +44,8 @@ class TestSQLSource(TestCase):
             if not os.environ.get('GREASE_TEST_DSN_ORIGINAL'):
                 os.environ['GREASE_TEST_DSN_ORIGINAL'] = os.environ.get('GREASE_TEST_DSN')
             os.environ['GREASE_TEST_DSN'] = os.environ['GREASE_TEST_DSN'] + " dbname=test_data"
-        except:
-            print("Exception occurred")
+        except psycopg2.Error as e:
+            print("psycopg2 Exception occurred, {}".format(e.pgerror))
 
     def __cleanup_schema(self):
         with psycopg2.connect(os.environ['GREASE_TEST_DSN_ORIGINAL']) as conn:

--- a/tgt_grease/enterprise/Sources/tests/test_sql_parser.py
+++ b/tgt_grease/enterprise/Sources/tests/test_sql_parser.py
@@ -44,6 +44,7 @@ class TestSQLSource(TestCase):
             if not os.environ.get('GREASE_TEST_DSN_ORIGINAL'):
                 os.environ['GREASE_TEST_DSN_ORIGINAL'] = os.environ.get('GREASE_TEST_DSN')
             os.environ['GREASE_TEST_DSN'] = os.environ['GREASE_TEST_DSN'] + " dbname=test_data"
+            
         except psycopg2.Error as e:
             print("psycopg2 Exception occurred, {}".format(e.pgerror))
 


### PR DESCRIPTION
# GREASE Developer Pull Request Checklist _Added generic Exception catch in Importer

  * Primary Contact: [Ronald Queensen](mailto:ronald.queensen@target.com)

### Purpose

Without this patch, if a command has an exception during its `__init__` (that is not a TypeError or AttributeError), that exception is not caught, and it can break GREASE. The motivation for this patch is that an imported library's random exception was not getting caught, causing unexpected  process termination.

Also cleaned up a few minor things in the affected method. 

### Expected Outcome

Backup Catch condition to prevent exceptions from slipping through, so no more crashes. Unspecified exception catching is bad, but there is no way to know what exceptions a command can throw during `__init__`.
  
### Checklist
 - [x] Tests
 - [x] Documentation
 - [x] Maintainer Code Review
