### PR TITLE
Fixed detection sorting: grease_data.createTime doesn't exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 setup(
     name='tgt_grease',
-    version='2.3.5',
+    version='2.3.6',
     license="MIT",
     description='Modern distributed automation engine built with love by Target',
     long_description="""

--- a/tgt_grease/enterprise/Model/Detection.py
+++ b/tgt_grease/enterprise/Model/Detection.py
@@ -105,7 +105,7 @@ class Detect(object):
                 'grease_data.detection.start': None,
                 'grease_data.detection.end': None,
             },
-            sort=[('grease_data.createTime', pymongo.DESCENDING)]
+            sort=[('createTime', pymongo.DESCENDING)]
         )
 
     def detection(self, source, configuration):

--- a/tgt_grease/enterprise/Model/tests/test_central_scheduling.py
+++ b/tgt_grease/enterprise/Model/tests/test_central_scheduling.py
@@ -243,7 +243,7 @@ class TestScheduling(TestCase):
                     'grease_data.scheduling.start': None,
                     'grease_data.scheduling.end': None
                 },
-                sort=[('grease_data.createTime', pymongo.DESCENDING)]
+                sort=[('createTime', pymongo.DESCENDING)]
             )
         ))
         d.ioc.getCollection('JobServer').delete_one({'_id': ObjectId(scheduleServer)})


### PR DESCRIPTION
# GREASE Developer Pull Request Checklist _Fixed detection sorting: grease_data.createTime doesn't exist_
###### USE THIS TEMPLATE FOR YOUR PULL REQUEST!

  * Primary Contact: [Cory Hollinger](mailto:cory.hollinger@target.com)

### Purpose

This sort will not do much because `grease_data.createTime` doesn't exist.

### Expected Outcome

Sorts correctly. Hooray.
  
### Checklist
 - [x] Maintainer Code Review
