### PR TITLE
default value for configuration should be an empty dict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 setup(
     name='tgt_grease',
-    version='2.3.5',
+    version='2.3.6',
     license="MIT",
     description='Modern distributed automation engine built with love by Target',
     long_description="""

--- a/tgt_grease/core/Configuration.py
+++ b/tgt_grease/core/Configuration.py
@@ -4,7 +4,7 @@ import json
 ##
 # Global Configuration Object
 ##
-GREASE_CONFIG = None
+GREASE_CONFIG = {}
 
 
 class Configuration(object):


### PR DESCRIPTION
# GREASE Developer Pull Request Checklist _replace with your PR title_
###### USE THIS TEMPLATE FOR YOUR PULL REQUEST!

  * Primary Contact: [Cory Hollinger](mailto:cory.hollinger@target.com)

### Purpose

The default value for the GREASE config global was `None`. This led to Errors when attempting to index with `.get` with a default value if the global config was inaccessible or not configured (such as when tests were run locally, as there should be no need for a configuration to be present for that). Making the default an empty dict fixes this issue, and is more correct in my opinion.

### Expected Outcome

Global configuration defaults to an empty dict.
  
### Checklist
 - [ ] Maintainer Code Review
