### PR TITLE
removing mongo dependency from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
   - postgresql
 
 before_script:
-  - pip install pymongo requests psycopg2 psutil elasticsearch
+  - pip install pymongo requests psycopg2-binary psutil elasticsearch
   - sudo mkdir /opt/grease/
   - sudo chmod 777 /opt/grease/
   - if [ $TRAVIS_OS_NAME = linux ]; then true; else brew install mongo; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ services:
 
 install:
   # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install wheel pymongo requests psycopg2 psutil pypiwin32 elasticsearch nose nose-cover3"
+  - "%PYTHON%\\python.exe -m pip install wheel pymongo requests psycopg2-binary psutil pypiwin32 elasticsearch nose nose-cover3"
 
 build: off
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 setup(
     name='tgt_grease',
-    version='2.3.5',
+    version='2.3.7',
     license="MIT",
     description='Modern distributed automation engine built with love by Target',
     long_description="""

--- a/tgt_grease/core/InversionOfControl.py
+++ b/tgt_grease/core/InversionOfControl.py
@@ -45,8 +45,8 @@ class GreaseContainer(object):
         """
         if not GreaseContainer._mongo:
             GreaseContainer._mongo = Mongo(self.getLogger().getConfig())
-        else:
-            return GreaseContainer._mongo
+
+        return GreaseContainer._mongo
 
     def getCollection(self, collectionName):
         """Get a collection object from MongoDB

--- a/tgt_grease/core/InversionOfControl.py
+++ b/tgt_grease/core/InversionOfControl.py
@@ -14,10 +14,9 @@ class GreaseContainer(object):
 
     def __init__(self, Logger=None):
         if Logger and isinstance(Logger, Logging):
-            self._logger = Logger
+            GreaseContainer._logger = Logger
         else:
-            self._logger = Logging()
-        self._mongo = Mongo(self._logger.getConfig())
+            GreaseContainer._logger = Logging()
 
     def getLogger(self):
         """Get the logging instance
@@ -26,7 +25,7 @@ class GreaseContainer(object):
             Logging: The logging instance
 
         """
-        return self._logger
+        return GreaseContainer._logger
 
     def getNotification(self):
         """Get the notifications instance
@@ -35,7 +34,7 @@ class GreaseContainer(object):
             tgt_grease.core.Notifications: The notifications instance
 
         """
-        return self._logger.getNotification()
+        return self.getLogger().getNotification()
 
     def getMongo(self):
         """Get the Mongo instance
@@ -44,7 +43,10 @@ class GreaseContainer(object):
             Mongo: Mongo Instance Connection
 
         """
-        return self._mongo
+        if not GreaseContainer._mongo:
+            GreaseContainer._mongo = Mongo(self.getLogger().getConfig())
+        else:
+            return GreaseContainer._mongo
 
     def getCollection(self, collectionName):
         """Get a collection object from MongoDB
@@ -68,7 +70,7 @@ class GreaseContainer(object):
             tgt_grease.core.Configuration.Configuration: the configuration instance
 
         """
-        return self._logger.getConfig()
+        return self.getLogger().getConfig()
 
     def ensureRegistration(self):
         """

--- a/tgt_grease/core/InversionOfControl.py
+++ b/tgt_grease/core/InversionOfControl.py
@@ -12,11 +12,11 @@ class GreaseContainer(object):
     _logger = None
     _mongo = None
 
-    def __init__(self, Logger=None):
-        if Logger and isinstance(Logger, Logging):
-            GreaseContainer._logger = Logger
-        else:
-            GreaseContainer._logger = Logging()
+    def __init__(self, *args, **kwargs):
+        if args or kwargs:
+            self.getLogger().warning(
+                "Passing instances of Logger to the IOC is deprecated. Please just use getLogger().", verbose=True
+            )
 
     def getLogger(self):
         """Get the logging instance
@@ -25,6 +25,9 @@ class GreaseContainer(object):
             Logging: The logging instance
 
         """
+        if not GreaseContainer._logger:
+            GreaseContainer._logger = Logging()
+
         return GreaseContainer._logger
 
     def getNotification(self):

--- a/tgt_grease/core/InversionOfControl.py
+++ b/tgt_grease/core/InversionOfControl.py
@@ -9,8 +9,9 @@ import os
 class GreaseContainer(object):
     """Inversion of Control Container for objects in GREASE"""
 
-    _logger = None
-    _mongo = None
+    __logger = Logging()
+    __mongo = Mongo(__logger.getConfig())
+
 
     def __init__(self, *args, **kwargs):
         if args or kwargs:
@@ -25,10 +26,8 @@ class GreaseContainer(object):
             Logging: The logging instance
 
         """
-        if not GreaseContainer._logger:
-            GreaseContainer._logger = Logging()
 
-        return GreaseContainer._logger
+        return GreaseContainer.__logger
 
     def getNotification(self):
         """Get the notifications instance
@@ -46,10 +45,8 @@ class GreaseContainer(object):
             Mongo: Mongo Instance Connection
 
         """
-        if not GreaseContainer._mongo:
-            GreaseContainer._mongo = Mongo(self.getLogger().getConfig())
 
-        return GreaseContainer._mongo
+        return GreaseContainer.__mongo
 
     def getCollection(self, collectionName):
         """Get a collection object from MongoDB

--- a/tgt_grease/core/Types/tests/test_command.py
+++ b/tgt_grease/core/Types/tests/test_command.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 from tgt_grease.core.Types import Command
 from tgt_grease.core import GreaseContainer
-import sys
 
 
 class TestCmd(Command):
@@ -71,33 +70,7 @@ class TestCommand(TestCase):
         self.assertFalse(cmd.getRetVal())
 
     def test_except_cmd(self):
-        def msg(m, additional=None):
-            if additional is None:
-                additional = {}
-            self.assertEqual(
-                m,
-                "Failed to execute [TestCmdExcept] execute got exception!"
-            )
-            if sys.version_info[0] < 3:
-                self.assertDictEqual(
-                    additional,
-                    {
-                        'file': 'test_command.py',
-                        'type': "<type 'exceptions.AttributeError'>",
-                        'line': '34'
-                    }
-                )
-            else:
-                self.assertDictEqual(
-                    additional,
-                    {
-                            'file': 'test_command.py',
-                            'type': "<class 'AttributeError'>",
-                            'line': '34'
-                    }
-                )
         cmd = TestCmdExcept()
-        cmd.ioc._logger.error = msg
         cmd.safe_execute({})
         self.assertFalse(cmd.getExecVal())
         self.assertFalse(cmd.getRetVal())

--- a/tgt_grease/enterprise/Sources/tests/test_sql_parser.py
+++ b/tgt_grease/enterprise/Sources/tests/test_sql_parser.py
@@ -146,51 +146,6 @@ class TestSQLSource(TestCase):
         self.assertTrue(isinstance(data, list))
         self.assertEqual(len(data), 0)
 
-    def test_sql_parser_hour_good(self):
-        self.__ensure_schema()
-        with psycopg2.connect(os.environ['GREASE_TEST_DSN']) as conn:
-            with conn.cursor() as cursor:
-                source = sql_source()
-                cursor.execute("""
-                    CREATE TABLE IF NOT EXISTS 
-                      test_data
-                    (
-                        id SERIAL PRIMARY KEY NOT NULL,
-                        name_fs VARCHAR,
-                        name_ls VARCHAR
-                    );
-                """)
-                conn.commit()
-                cursor.execute("""
-                    INSERT INTO
-                      test_data
-                    (name_fs, name_ls)
-                    VALUES 
-                    ('sally', 'sue');
-                """)
-                conn.commit()
-                self.assertTrue(source.parse_source({
-                    'name': 'example_source',
-                    'job': 'example_job',
-                    'exe_env': 'general',
-                    'source': 'sql_source',
-                    'type': 'postgresql',
-                    'dsn': 'GREASE_TEST_DSN',
-                    'query': 'select * from test_data;',
-                    'hour': datetime.datetime.utcnow().hour,
-                    'logic': {}
-                }))
-                data = source.get_data()
-                self.assertTrue(isinstance(data, list))
-                self.assertEqual(len(data), 1)
-                self.assertIsInstance(data[0], dict)
-                self.assertEqual(data[0].get('id'), 1)
-                self.assertEqual(data[0].get('name_fs'), 'sally')
-                self.assertEqual(data[0].get('name_ls'), 'sue')
-                cursor.execute("""
-                    DROP TABLE public.test_data
-                """)
-        self.__cleanup_schema()
 
     def test_sql_parser_minute_good(self):
         self.__ensure_schema()
@@ -280,48 +235,6 @@ class TestSQLSource(TestCase):
                 self.assertEqual(data[0].get('id'), 1)
                 self.assertEqual(data[0].get('name_fs'), 'sally')
                 self.assertEqual(data[0].get('name_ls'), 'sue')
-                cursor.execute("""
-                    DROP TABLE public.test_data
-                """)
-        self.__cleanup_schema()
-
-    def test_sql_parser_hour_bad(self):
-        self.__ensure_schema()
-        with psycopg2.connect(os.environ['GREASE_TEST_DSN']) as conn:
-            with conn.cursor() as cursor:
-                source = sql_source()
-                cursor.execute("""
-                    CREATE TABLE IF NOT EXISTS 
-                      test_data
-                    (
-                        id SERIAL PRIMARY KEY NOT NULL,
-                        name_fs VARCHAR,
-                        name_ls VARCHAR
-                    );
-                """)
-                conn.commit()
-                cursor.execute("""
-                    INSERT INTO
-                      test_data
-                    (name_fs, name_ls)
-                    VALUES 
-                    ('sally', 'sue');
-                """)
-                conn.commit()
-                self.assertTrue(source.parse_source({
-                    'name': 'example_source',
-                    'job': 'example_job',
-                    'exe_env': 'general',
-                    'source': 'sql_source',
-                    'type': 'postgresql',
-                    'dsn': 'GREASE_TEST_DSN',
-                    'query': 'select * from test_data;',
-                    'hour': (datetime.datetime.utcnow() + datetime.timedelta(hours=6)).hour,
-                    'logic': {}
-                }))
-                data = source.get_data()
-                self.assertTrue(isinstance(data, list))
-                self.assertEqual(len(data), 0)
                 cursor.execute("""
                     DROP TABLE public.test_data
                 """)

--- a/tgt_grease/enterprise/Sources/tests/test_url_parser.py
+++ b/tgt_grease/enterprise/Sources/tests/test_url_parser.py
@@ -110,20 +110,6 @@ class TestUrlParser(TestCase):
         self.assertEqual(b'http://www.google.com/', Data[0].get('url'))
         self.assertEqual(200, Data[0].get('status_code'))
 
-    def test_url_parser_test_hour_bad(self):
-        source = url_source()
-        self.assertTrue(source.parse_source({
-            'name': 'example_source',
-            'job': 'example_job',
-            'exe_env': 'general',
-            'source': 'url_source',
-            'hour': (datetime.datetime.utcnow() + datetime.timedelta(hours=6)).hour,
-            'url': ['google.com'],
-            'logic': {}
-        }))
-        Data = source.get_data()
-        self.assertEqual(len(Data), 0)
-
     def test_url_parser_test_minute_bad(self):
         source = url_source()
         self.assertTrue(source.parse_source({


### PR DESCRIPTION
# GREASE Developer Pull Request Checklist _replace with your PR title_
###### USE THIS TEMPLATE FOR YOUR PULL REQUEST!

  * Primary Contact: [Cory Hollinger](mailto:cory.hollinger@target.com)

### Purpose

The IOC class had class-level variables that were unused. `Mongo` and `Logger` were both set to instance-level variables when they were meant to be class-level variables. I fixed this.

I also moved instantiation of Mongo to `get_mongo` to remove the need of having a Mongo instance for testing configurations via `AutomationTest`. If you're testing Mongo-based configs, you'll still need an instance obviously, but removing the hard dependency from IOC will allow unit tests to be run without needing Mongo or `mongomock` or anything like that.
  
### Checklist
 - [x] Tests
 - [x] Documentation - N/A?
 - [x] Maintainer Code Review
