### PR TITLE
WIP: inverting sourcing

### DIFF
--- a/tgt_grease/enterprise/Model/BaseSource.py
+++ b/tgt_grease/enterprise/Model/BaseSource.py
@@ -21,6 +21,7 @@ class BaseSourceClass(object):
         self.deduplication_expiry = 12
         self.deduplication_expiry_max = 7
         self.field_set = None
+        self.group_by = []
 
     @abstractmethod
     def mock_data(self, configuration):

--- a/tgt_grease/enterprise/Model/Scanning.py
+++ b/tgt_grease/enterprise/Model/Scanning.py
@@ -32,7 +32,7 @@ class Scan(object):
         self.dedup = Deduplication(self.ioc)
         self.scheduler = Scheduling(self.ioc)
 
-    def Parse(self, src=None, config=None):
+    def Parse(self, source=None, config=None):
         """This will read all configurations and attempt to scan the environment
 
         This is the primary business logic for scanning in GREASE. This method will use configurations to parse
@@ -55,21 +55,21 @@ class Scan(object):
 
         """
         self.ioc.getLogger().trace("Starting Parse of Environment", trace=True)
-        sources = self.conf.get_sources() if not src else [src]
+        sources = self.conf.get_sources() if not source else [source]
         ScanPool = []
-        for source in sources:
+        for src in sources:
             # ensure no kafka prototypes come into sourcing
-            if source == 'kafka':
+            if src == 'kafka':
                 continue
 
-            inst = self.impTool.load(source)
+            inst = self.impTool.load(src)
             if not isinstance(inst, BaseSourceClass):
                 self.ioc.getLogger().error("Invalid Source [{0}]".format(source), notify=False)
                 del inst
                 continue
             else:
                 # If the source wants us to bundle, do it
-                bundled = self.bundle_configs(source, self.generate_config_set(source=source, config=config))
+                bundled = self.bundle_configs(src, self.generate_config_set(source=source, config=config))
                 for sentinel_conf in bundled:
                     # ensure we don't swamp the system resources
                     cpu = cpu_percent(interval=.1)


### PR DESCRIPTION
# GREASE Developer Pull Request Checklist _replace with your PR title_
###### USE THIS TEMPLATE FOR YOUR PULL REQUEST!

  * Primary Contact: [Cory Hollinger](mailto:cory.hollinger@target.com)

### Purpose

Right now, sourcing happens per configuration, no matter what. This adds the option to bundle by keys that are specified per-source. If it is unspecified, then sourcing continues to happen as is.

One caveat is that bundling cannot be paired with custom configuration keys if those keys are not used for the bundling. For example, say you're bundling a source with configs of the following form by `key1`. `key2` will not be usable on a per-config basis because individual configs will no longer be accessed. To continue using the custom configuration key `key2`, bundling must NOT be enabled. However, if ONLY `key1` was present, and they are bundled by `key1`, then there is no issue. Hopefully that makes sense!

```json
{
  "source": "my_source",
  "key1": "value1",
  "key2": "value2",
  "Logic": ...
}
```

### Expected Outcome

Sourcing is more efficient because we have the ability to use one set of representative data for a group of configurations instead of many sets.
  
### Checklist
 - [ ] Tests
 - [ ] Documentation
 - [ ] Maintainer Code Review
