### PR TITLE
Changed HTTPError to RequestException in Notifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose', 'nose-cover3', 'mock'],
     install_requires=[
+        'urllib3==1.24.3',
         'psycopg2-binary',
         'requests',
         'pymongo',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 setup(
     name='tgt_grease',
-    version='2.6.0',
+    version='2.6.1',
     license="MIT",
     description='Modern distributed automation engine built with love by Target',
     long_description="""

--- a/tgt_grease/core/Notifier.py
+++ b/tgt_grease/core/Notifier.py
@@ -1,6 +1,5 @@
 from tgt_grease.core import Configuration
 from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
-from urllib3.exceptions import HTTPError
 import requests
 import json
 
@@ -147,7 +146,7 @@ class Notifications(object):
                 return True
             else:
                 return False
-        except HTTPError:
+        except requests.exceptions.RequestException:
             return False
 
     def send_slack_message(self, message):
@@ -170,6 +169,5 @@ class Notifications(object):
                 headers={'Content-Type': 'application/json'}
             )
             return True
-        except HTTPError:
+        except requests.exceptions.RequestException:
             return False
-


### PR DESCRIPTION
# Changed HTTPError to RequestException in Notifier

  * Primary Contact: [Cameron Hall](mailto:cjhall1283@gmail.com)

### Purpose

`RequestException` is used as a base exception for a majority of exceptions in the requests package while `urllib3.exceptions.HTTPError` is only used as a base exception for a `ContentDecodingError`. Fewer exceptions will make it through now.

https://3.python-requests.org/_modules/requests/exceptions/

### Expected Outcome

Exceptions like `ConnectionError` will now be caught as well as `ContentDecodingError`
  
### Checklist
 - [x] Tests
 - [x] Documentation
 - [ ] Maintainer Code Review
